### PR TITLE
Rename `masih` references to `filecoin-shipyard`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,12 @@ Thank you for your interest in contributing to Telefil! Your efforts will help m
 
 2. **Clone Your Fork**: Open a terminal and run:
    ```
-   git clone https://github.com/masih/telefil.git
+   git clone https://github.com/filecoin-shipyard/telefil.git
    ```
 
 3. **Add the Upstream Remote**: This will be useful to sync your fork with the latest changes:
    ```
-   git remote add upstream https://github.com/masih/telefil.git
+   git remote add upstream https://github.com/filecoin-shipyard/telefil.git
    ```
 
 4. **Create a New Branch**: Always base your work on a new branch:
@@ -54,7 +54,7 @@ Thank you for your interest in contributing to Telefil! Your efforts will help m
 
 ## Feedback
 
-If you're unsure about any aspect of the contribution process, please open an [issue](https://github.com/masih/telefil/issues). We're here to help!
+If you're unsure about any aspect of the contribution process, please open an [issue](https://github.com/filecoin-shipyard/telefil/issues). We're here to help!
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # :satellite: Telefil
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/masih/telefil.svg)](https://pkg.go.dev/github.com/masih/telefil)
-[![Go Test](https://github.com/masih/telefil/actions/workflows/go-test.yml/badge.svg)](https://github.com/masih/telefil/actions/workflows/go-test.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/filecoin-shipyard/telefil.svg)](https://pkg.go.dev/github.com/filecoin-shipyard/telefil)
+[![Go Test](https://github.com/filecoin-shipyard/telefil/actions/workflows/go-test.yml/badge.svg)](https://github.com/filecoin-shipyard/telefil/actions/workflows/go-test.yml)
 
 > Filecoin API client in pure Go
 
@@ -21,7 +21,7 @@ Filecoin API interactions provided by Telefil are:
 ## Installation
 
 ```bash
-go get github.com/masih/telefil@latest
+go get github.com/filecoin-shipyard/telefil@latest
 ```
 
 ## Status
@@ -35,7 +35,7 @@ updating.
 ## Documentation
 
 For detailed usage and integration guidance, please refer
-to [godoc documentation](https://pkg.go.dev/github.com/masih/telefil).
+to [godoc documentation](https://pkg.go.dev/github.com/filecoin-shipyard/telefil).
 
 ## Contribution
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/masih/telefil
+module github.com/filecoin-shipyard/telefil
 
 go 1.20
 

--- a/telefil_test.go
+++ b/telefil_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/masih/telefil"
+	"github.com/filecoin-shipyard/telefil"
 )
 
 func Test(t *testing.T) {


### PR DESCRIPTION
Now that the code is moved to `filecoin-shipyard`, rename references to the old repo.